### PR TITLE
update to alpine:3.8 to avoid openssl error

### DIFF
--- a/easyrsa/Dockerfile
+++ b/easyrsa/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk add --no-cache --upgrade openssl tar && \
     addgroup -g 101 radius && \


### PR DESCRIPTION
alpine:3.6 returns the following error:

```
Step 5/7 : RUN wget -qO- https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-3.0.1.tgz | tar xvz --strip-components=1 &&     chmod u+x entrypoint.sh
 ---> Running in 0602c20e7490
ssl_client: github.com: TLS connect failed
wget: error getting response: Connection reset by peer
gzip: invalid magic
tar: Child returned status 1
tar: Error is not recoverable: exiting now
The command '/bin/sh -c wget -qO- https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-3.0.1.tgz | tar xvz --strip-components=1 &&     chmod u+x entrypoint.sh' returned a non-zero code: 2
```

alpine:3.8 fixes it